### PR TITLE
Fix for launcher overdub toggle

### DIFF
--- a/osc/OSCParser.js
+++ b/osc/OSCParser.js
@@ -79,8 +79,6 @@ OSCParser.prototype.parse = function (msg)
 			break;
 
 		case 'overdub':
-            if (value != null && value == 0)
-                return;
             if (oscParts.length > 0 && oscParts[0] == 'launcher')
                 this.transport.toggleLauncherOverdub ();
             else


### PR DESCRIPTION
This patch is designed to work with an update to the Lemur template described in https://github.com/Lucid-Network/Lemur4Bitwig-Template/pull/1.

That PR updates the paths sent by the template for launcher overdub and autowrite to be /overdub/launcher and /autowrite/launcher instead of starting with /launcher (see also https://github.com/git-moss/OSC4Bitwig/wiki for expected paths).

The update to the script allows the launcher overdub setting to be toggled with each switch press in the template.  Otherwise the toggle only changes when a 1 is received (the 0 is a noop due to the return in the script).